### PR TITLE
fix: 카카오 인증 확인 오류

### DIFF
--- a/src/features/auth/routes/KakaoCallback.tsx
+++ b/src/features/auth/routes/KakaoCallback.tsx
@@ -23,7 +23,7 @@ const KakaoCallback = (): JSX.Element | null => {
         setIsLoading(true);
         const response = await postKakaoLogin({ data: { code } });
 
-        if (!response.ok) {
+        if (response.status < 200 || response.status >= 300) {
           throw new Error("카카오 인증에 실패했습니다.");
         }
 


### PR DESCRIPTION
기존에 fetch에서 사용하는 response.ok를 체크하는 방식이었는데, Axios는 response.ok가 없어서 인증 오류가 발생했어요. response.status를 200~299 범위로 체크하는 방식으로 수정해서 정상 동작하도록 변경했습니다.

